### PR TITLE
при отсутствии параметра full_icon_name в конфиге костюма теперь используется иконка визуала

### DIFF
--- a/xrGame/CustomOutfit.cpp
+++ b/xrGame/CustomOutfit.cpp
@@ -74,10 +74,7 @@ void CCustomOutfit::Load(LPCSTR section)
 	else
 		m_NightVisionSect = NULL;
 
-	if (pSettings->line_exist(section, "full_icon_name"))
-		m_full_icon_name = pSettings->r_string(section, "full_icon_name");
-	else
-		m_full_icon_name = NULL;
+	m_full_icon_name = READ_IF_EXISTS(pSettings, r_string, section, "full_icon_name", nullptr);
 }
 
 void CCustomOutfit::Hit(float hit_power, ALife::EHitType hit_type)

--- a/xrGame/CustomOutfit.cpp
+++ b/xrGame/CustomOutfit.cpp
@@ -74,7 +74,10 @@ void CCustomOutfit::Load(LPCSTR section)
 	else
 		m_NightVisionSect = NULL;
 
-	m_full_icon_name = pSettings->r_string(section, "full_icon_name");
+	if (pSettings->line_exist(section, "full_icon_name"))
+		m_full_icon_name = pSettings->r_string(section, "full_icon_name");
+	else
+		m_full_icon_name = NULL;
 }
 
 void CCustomOutfit::Hit(float hit_power, ALife::EHitType hit_type)

--- a/xrGame/ui/UIOutfitSlot.cpp
+++ b/xrGame/ui/UIOutfitSlot.cpp
@@ -35,56 +35,41 @@ void CUIOutfitDragDropList::SetOutfit(CUICellItem *itm)
 
 	m_background->SetStretchTexture(true);
 
-	if ((GameID() != GAME_SINGLE) && !itm)
+	xr_string icon = *m_default_outfit;
+	bool usevisual = GameID() != GAME_SINGLE;
+	if (itm)
 	{
-		CObject *pActor = NULL;
+		PIItem _iitem = (PIItem)itm->m_pData;
+		CCustomOutfit* pOutfit = smart_cast<CCustomOutfit*>(_iitem);
+		VERIFY(pOutfit);
 
-		pActor = smart_cast<CActor *>(Level().CurrentEntity());
-
-		xr_string a;
-		if (pActor)
-			a = *pActor->cNameVisual();
-		else
-			a = *m_default_outfit;
-
-		xr_string::iterator it = std::find(a.rbegin(), a.rend(), '\\').base();
-
-		// Cut leading full path
-		if (it != a.begin())
-			a.erase(a.begin(), it);
-		// Cut trailing ".ogf"
-		R_ASSERT(xr_strlen(a.c_str()) > 4);
-		if ('.' == a[a.size() - 4])
-			a.erase(a.size() - 4);
-
-		m_background->InitTexture(a.c_str());
+		if (pOutfit->GetFullIconName().size())
+		{
+			icon = pOutfit->GetFullIconName().c_str();
+			usevisual = false;
+		}
 	}
-	else
+
+	if (usevisual)
 	{
-		if (itm)
+		if (CObject* pActor = smart_cast<CActor*>(Level().CurrentEntity()))
 		{
-			PIItem _iitem = (PIItem)itm->m_pData;
-			CCustomOutfit *pOutfit = smart_cast<CCustomOutfit *>(_iitem);
-			VERIFY(pOutfit);
-			/*
-			r.lt			= pOutfit->GetIconPos();
-			r.x1			*= ICON_GRID_WIDTH;
-			r.y1			*= ICON_GRID_HEIGHT;
-			*/
-			m_background->InitTexture(pOutfit->GetFullIconName().c_str());
-		}
-		else
-		{
-			m_background->InitTexture("npc_icon_without_outfit");
-		}
-		/*
-		r.x2			= r.x1+CHAR_ICON_FULL_WIDTH*ICON_GRID_WIDTH;
-		r.y2			= r.y1+CHAR_ICON_FULL_HEIGHT*ICON_GRID_HEIGHT;
+			xr_string a = *pActor->cNameVisual();
 
-		m_background->SetShader				(InventoryUtilities::GetCharIconsShader());
-        m_background->SetOriginalRect		(r);
-		*/
+			xr_string::iterator it = std::find(a.rbegin(), a.rend(), '\\').base();
+
+			// Cut leading full path
+			if (it != a.begin())
+				a.erase(a.begin(), it);
+			// Cut trailing ".ogf"
+			R_ASSERT(xr_strlen(a.c_str()) > 4);
+			if ('.' == a[a.size() - 4])
+				a.erase(a.size() - 4);
+
+			icon = a.c_str();
+		}
 	}
+	m_background->InitTexture(icon.c_str());
 
 	m_background->TextureAvailable(true);
 	m_background->TextureOn();


### PR DESCRIPTION
механика иконки по визуалу уже есть, но работает только в МП и только если нет комбеза.
эта правка расширяет возможности. если full_icon_name есть, то она будет использоваться всегда, для обоих команд, вне зависимости от визуала, если её нет, то будет браться иконка визуала.
так можно будет иметь один комбез в игре, который будет иметь разные визуалы и заодно теперь и иконку в инвентаре.
в одиночной игре функционал не изменился: если комбез есть и есть иконка, то будет использоваться иконка, если комбеза нет, то будет стандартная иконка npc_icon_without_outfit, а если есть комбез, но нет строки full_icon_name, то вылет, как и в оригинале. решил не трогать это