### PR TITLE
экспорт в скрипты

### DIFF
--- a/xrGame/actor_communication.cpp
+++ b/xrGame/actor_communication.cpp
@@ -134,6 +134,8 @@ bool CActor::OnReceiveInfo(shared_str info_id) const
 	Msg("- actor: %s received: [%s]", Name(), info_id.c_str());
 #endif
 
+	callback(GameObject::eInventoryInfo)(lua_game_object(), *info_id);
+
 	if (Actor() != this)
 		return true;
 
@@ -142,8 +144,6 @@ bool CActor::OnReceiveInfo(shared_str info_id) const
 
 	AddEncyclopediaArticle(&info_portion);
 	AddGameTask(&info_portion);
-
-	callback(GameObject::eInventoryInfo)(lua_game_object(), *info_id);
 
 	if (!HUD().GetUI())
 		return false;

--- a/xrGame/game_base_script.cpp
+++ b/xrGame/game_base_script.cpp
@@ -42,6 +42,7 @@ void game_PlayerState::script_register(lua_State *L)
 			 .def_readwrite("rank", &BaseType::rank)
 			 .def_readwrite("DeathTime", &BaseType::DeathTime)
 			 .def_readwrite("m_online_time", &BaseType::m_online_time)
+			 .def_readwrite("m_bPayForSpawn", &BaseType::m_bPayForSpawn)
 
 			 .def_readwrite("m_Stats", &BaseType::m_Stats)
 

--- a/xrGame/game_cl_mp_script.cpp
+++ b/xrGame/game_cl_mp_script.cpp
@@ -111,6 +111,7 @@ void game_cl_mp::script_register(lua_State *L)
 			.def(constructor<>())
 			.def_readwrite("UID", &xrClientData::UID)
 			.def_readwrite("ps", &xrClientData::ps)
+			.def_readwrite("ID", &xrClientData::ID)
 			.def("GetIP", &xrClientData::GetIP),
 
 		 class_<game_cl_mp, game_cl_GameState>("game_cl_mp")];

--- a/xrGame/game_cl_mp_script.cpp
+++ b/xrGame/game_cl_mp_script.cpp
@@ -110,7 +110,8 @@ void game_cl_mp::script_register(lua_State *L)
 			class_<xrClientData>("xrClientData")
 			.def(constructor<>())
 			.def_readwrite("UID", &xrClientData::UID)
-			.def_readwrite("ps", &xrClientData::ps),
+			.def_readwrite("ps", &xrClientData::ps)
+			.def("GetIP", &xrClientData::GetIP),
 
 		 class_<game_cl_mp, game_cl_GameState>("game_cl_mp")];
 }

--- a/xrGame/game_sv_mp_script.cpp
+++ b/xrGame/game_sv_mp_script.cpp
@@ -205,7 +205,9 @@ void game_sv_mp::script_register(lua_State *L)
 			 .def("release", &game_sv_mp::Release)
 			 .def("set_visual", &game_sv_mp::SetVisual)
 			 .def("GetTeamScore", &game_sv_Deathmatch::GetTeamScore)
-			 .def("SetTeamScore", &game_sv_Deathmatch::SetTeamScore)];
+			 .def("SetTeamScore", &game_sv_Deathmatch::SetTeamScore)
+			 .def("OnPlayerReady", &game_sv_mp::OnPlayerReady)
+			 .def("RespawnPlayer", &game_sv_mp::RespawnPlayer)];
 }
 
 void game_sv_mp_script::script_register(lua_State *L)

--- a/xrGame/xrServer.h
+++ b/xrGame/xrServer.h
@@ -53,6 +53,11 @@ public:
 	xrClientData();
 	virtual ~xrClientData();
 	virtual void Clear();
+	LPCSTR GetIP() {
+		string4096 str = "";
+		strcpy_s(str, m_cAddress.to_string().c_str());
+		return str;
+	}
 };
 
 // main


### PR DESCRIPTION
ID и GetIP для возможности идентифицировать игроков на стороне сервера
m_bPayForSpawn, OnPlayerReady и RespawnPlayer для респавна игрока через скрипты
RespawnPlayer для прямого респавна игрока, в обход обработки магазина и т.д.
OnPlayerReady и m_bPayForSpawn для симуляции добровольного респавна игрока, учитывая закуп
также исправлено срабатывание инфопоршня eInventoryInfo для акторов, помимо локального